### PR TITLE
Fix an UnboundLocalError from psrcat tarball status check

### DIFF
--- a/psrqpy/utils.py
+++ b/psrqpy/utils.py
@@ -381,10 +381,8 @@ def download_atnf_tarball(url, usecache=True, version="latest"):
 
     try:
         tarfile = requests.get(url)
+        tarfile.raise_for_status()
     except Exception as e:
-        raise RuntimeError("Error downloading pulsar catalogue: {}".format(str(e)))
-
-    if tarfile.status_code != 200:
         raise RuntimeError("Error downloading pulsar catalogue: {}".format(str(e)))
 
     if not os.path.exists(CACHEDIR):


### PR DESCRIPTION
Ran into an issue where I was getting an undefined error for an error variable while looking up an older version of the catalogue, turned out to be a side effect of a sub-function call that was using the same variable name for the error, except in that case it was never defined.

Better way of checking the return: ask requests to raise an error in the case that the download did not proceed as expected. ( https://requests.readthedocs.io/en/master/api/#requests.Response.raise_for_status )

Quick repro test (the v isn't meant to be in the version string):
```python
import psrqpy
query = psrqpy.QueryATNF(psrtype = "RRAT", version = 'v1.64')
```

Before:

> 
> In [2]: query = psrqpy.QueryATNF(psrtype = "RRAT", version = 'v1.64')
> local variable 'e' referenced before assignment
> ---------------------------------------------------------------------------
> UnboundLocalError                         Traceback (most recent call last)
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:351, in QueryATNF.get_catalogue(self, path_to_db, cache, update, overwrite, version)
>     350 try:
> --> 351     dbtable = get_catalogue(path_to_db=path_to_db, cache=cache,
>     352                             update=update, pandas=True,
>     353                             version=version)
>     354 except Exception as e:
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:93, in get_catalogue(path_to_db, cache, update, pandas, version)
>      92 try:
> ---> 93     dbtarfile = download_atnf_tarball(
>      94         atnftarball, usecache=cache, version=version
>      95     )
>      96 except RuntimeError as e:
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:388, in download_atnf_tarball(url, usecache, version)
>     387 if tarfile.status_code != 200:
> --> 388     raise RuntimeError("Error downloading pulsar catalogue: {}".format(str(e)))
>     390 if not os.path.exists(CACHEDIR):
> 
> UnboundLocalError: local variable 'e' referenced before assignment
> 
> During handling of the above exception, another exception occurred:
> 
> RuntimeError                              Traceback (most recent call last)
> Input In [2], in <cell line: 1>()
> ----> 1 query = psrqpy.QueryATNF(psrtype = "RRAT", version = 'v1.64')
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:216, in QueryATNF.__init__(self, params, condition, psrtype, assoc, bincomp, exactmatch, sort_attr, sort_order, psrs, include_errs, include_refs, adsref, loadfromfile, loadquery, loadfromdb, cache, checkupdate, circular_boundary, coord1, coord2, radius, frompandas, fromtable, version)
>     214 # download and cache (if requested) the database file
>     215 try:
> --> 216     _ = self.get_catalogue(path_to_db=loadfromdb, cache=cache,
>     217                            update=checkupdate, version=version)
>     218 except IOError:
>     219     raise IOError("Could not get catalogue database file")
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:356, in QueryATNF.get_catalogue(self, path_to_db, cache, update, overwrite, version)
>     354 except Exception as e:
>     355     print(e)
> --> 356     raise RuntimeError("Problem getting catalogue: {}".format(str(e)))
>     358 if not cache:
>     359     if not overwrite:
> 
> RuntimeError: Problem getting catalogue: local variable 'e' referenced before assignment


After (seems to be several except/raise errors chained, but matched the previous behaviour for an error in the function):

> In [2]: query = psrqpy.QueryATNF(psrtype = "RRAT", version = 'v1.64')
> Problem accessing ATNF catalogue tarball: http://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> Error downloading pulsar catalogue: 404 Client Error: Not Found for url: https://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> ---------------------------------------------------------------------------
> HTTPError                                 Traceback (most recent call last)
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:388, in download_atnf_tarball(url, usecache, version)
>     387 try:
> --> 388     tarfile.raise_for_status()
>     389 except requests.exceptions.HTTPError as e:
> 
> File /usr/lib/python3/dist-packages/requests/models.py:943, in Response.raise_for_status(self)
>     942 if http_error_msg:
> --> 943     raise HTTPError(http_error_msg, response=self)
> 
> HTTPError: 404 Client Error: Not Found for url: https://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> 
> During handling of the above exception, another exception occurred:
> 
> RuntimeError                              Traceback (most recent call last)
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:93, in get_catalogue(path_to_db, cache, update, pandas, version)
>      92 try:
> ---> 93     dbtarfile = download_atnf_tarball(
>      94         atnftarball, usecache=cache, version=version
>      95     )
>      96 except RuntimeError as e:
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:390, in download_atnf_tarball(url, usecache, version)
>     389 except requests.exceptions.HTTPError as e:
> --> 390     raise RuntimeError("Error downloading pulsar catalogue: {}".format(str(e)))
>     392 if not os.path.exists(CACHEDIR):
> 
> RuntimeError: Error downloading pulsar catalogue: 404 Client Error: Not Found for url: https://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> 
> During handling of the above exception, another exception occurred:
> 
> OSError                                   Traceback (most recent call last)
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:351, in QueryATNF.get_catalogue(self, path_to_db, cache, update, overwrite, version)
>     350 try:
> --> 351     dbtable = get_catalogue(path_to_db=path_to_db, cache=cache,
>     352                             update=update, pandas=True,
>     353                             version=version)
>     354 except Exception as e:
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/utils.py:97, in get_catalogue(path_to_db, cache, update, pandas, version)
>      96 except RuntimeError as e:
> ---> 97     raise IOError(
>      98         f"Problem accessing ATNF catalogue tarball: {atnftarball}\n{e}"
>      99     )
>     101 try:
>     102     # open tarball
> 
> OSError: Problem accessing ATNF catalogue tarball: http://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> Error downloading pulsar catalogue: 404 Client Error: Not Found for url: https://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> 
> During handling of the above exception, another exception occurred:
> 
> RuntimeError                              Traceback (most recent call last)
> Input In [2], in <cell line: 1>()
> ----> 1 query = psrqpy.QueryATNF(psrtype = "RRAT", version = 'v1.64')
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:216, in QueryATNF.__init__(self, params, condition, psrtype, assoc, bincomp, exactmatch, sort_attr, sort_order, psrs, include_errs, include_refs, adsref, loadfromfile, loadquery, loadfromdb, cache, checkupdate, circular_boundary, coord1, coord2, radius, frompandas, fromtable, version)
>     214 # download and cache (if requested) the database file
>     215 try:
> --> 216     _ = self.get_catalogue(path_to_db=loadfromdb, cache=cache,
>     217                            update=checkupdate, version=version)
>     218 except IOError:
>     219     raise IOError("Could not get catalogue database file")
> 
> File ~/.local/lib/python3.10/site-packages/psrqpy/search.py:356, in QueryATNF.get_catalogue(self, path_to_db, cache, update, overwrite, version)
>     354 except Exception as e:
>     355     print(e)
> --> 356     raise RuntimeError("Problem getting catalogue: {}".format(str(e)))
>     358 if not cache:
>     359     if not overwrite:
> 
> RuntimeError: Problem getting catalogue: Problem accessing ATNF catalogue tarball: http://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz
> Error downloading pulsar catalogue: 404 Client Error: Not Found for url: https://www.atnf.csiro.au/people/pulsar/psrcat/downloads/psrcat_pkg.vv1.64.tar.gz

